### PR TITLE
Fixed a crash.

### DIFF
--- a/01_protocol_proxy/teleport_proxy.py
+++ b/01_protocol_proxy/teleport_proxy.py
@@ -70,7 +70,7 @@ class QuietBridge(Bridge):
 class QuietDownstreamFactory(DownstreamFactory):
     bridge_class = QuietBridge
     motd = "LiveOverflow Proxy"
-
+    online_mode = False
 
 # python basic_proxy.py -q 12345
 def main(argv):


### PR DESCRIPTION
If you try to run the current code, you will run into an error with mojang authentication (in `packet_login_encryption_request` from `protocol.py`) and the client and proxy return:
`Auth failed: [<twisted.python.failure.Failure OpenSSL.SSL.Error: [('STORE routines', '', 'unregistered scheme'), ('STORE routines', '', 'unsupported'), ('STORE routines', '', 'unregistered scheme'), ('system library', '', ''), ('STORE routines', '', 'unregistered scheme'), ('STORE routines', '', 'unsupported'), ('STORE routines', '', 'unregistered scheme'), ('system library', '', ''), ('STORE routines', '', 'unregistered scheme'), ('STORE routines', '', 'unsupported'), ('STORE routines', '', 'unregistered scheme'), ('system library', '', ''), ('STORE routines', '', 'unregistered scheme'), ('STORE routines', '', 'unsupported'), ('SSL routines', '', 'certificate verify failed')]>]
`
this is caused by the proxy defaulting to online mode in `ServerFactory` but the proxy is made to operate in offline mode to edit and read the unencrypted messages.

Edit:
I think this might only be on Windows.